### PR TITLE
feat: [CI-19419] Azure oidc plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ This plugin is designed exclusively for Service Principal authentication, which 
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `tenant_id` | string | Yes | - | The Azure AD Tenant ID (GUID or one of: `common`, `organizations`, `consumers`) |
+| `tenant_id` | string | Yes | - | The Azure AD Tenant ID (GUID format) |
 | `client_id` | string | Yes | - | The Azure AD Application (Client) ID (GUID format) |
 | `scope` | string | No | `https://management.azure.com/.default` | The Azure resource scope for the access token |
 | `azure_authority_host` | string | No | `https://login.microsoftonline.com` | The Azure AD authority host to use (set for national clouds like Azure Gov/China) |

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This plugin is designed exclusively for Service Principal authentication, which 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
 | `tenant_id` | string | Yes | - | The Azure AD Tenant ID (GUID or one of: `common`, `organizations`, `consumers`) |
-| `client_id` | string | Yes | - | The Azure AD Application (Client) ID (GUID) |
+| `client_id` | string | Yes | - | The Azure AD Application (Client) ID (GUID format) |
 | `scope` | string | No | `https://management.azure.com/.default` | The Azure resource scope for the access token |
 | `azure_authority_host` | string | No | `https://login.microsoftonline.com` | The Azure AD authority host to use (set for national clouds like Azure Gov/China) |
 

--- a/README.md
+++ b/README.md
@@ -18,16 +18,17 @@ This plugin is designed exclusively for Service Principal authentication, which 
 
 | Parameter | Type | Required | Default | Description |
 |-----------|------|----------|---------|-------------|
-| `tenant_id` | string | Yes | - | The Azure AD Tenant ID (GUID format) |
-| `client_id` | string | Yes | - | The Azure AD Application (Client) ID (GUID format) |
-| `scope` | string | No | `https://storage.azure.com/.default` | The Azure resource scope for the access token |
+| `tenant_id` | string | Yes | - | The Azure AD Tenant ID (GUID or one of: `common`, `organizations`, `consumers`) |
+| `client_id` | string | Yes | - | The Azure AD Application (Client) ID (GUID) |
+| `scope` | string | No | `https://management.azure.com/.default` | The Azure resource scope for the access token |
+| `azure_authority_host` | string | No | `https://login.microsoftonline.com` | The Azure AD authority host to use (set for national clouds like Azure Gov/China) |
 
 ## Supported Scopes
 
 | Service | Scope |
 |---------|-------|
-| Azure Storage (default) | `https://storage.azure.com/.default` |
-| Azure Management API | `https://management.azure.com/.default` |
+| Azure Management API (default) | `https://management.azure.com/.default` |
+| Azure Storage | `https://storage.azure.com/.default` |
 | Microsoft Graph | `https://graph.microsoft.com/.default` |
 | Azure Container Registry | `https://containerregistry.azure.net/.default` |
 | Azure Key Vault | `https://vault.azure.net/.default` |
@@ -56,7 +57,7 @@ The plugin `plugins/azure-oidc` is available for the following architectures:
 
 ## Usage Examples
 
-### Basic Authentication with Azure Storage
+### Basic Authentication with Azure Management
 
 ```yaml
 - step:
@@ -85,6 +86,23 @@ The plugin `plugins/azure-oidc` is available for the following architectures:
         tenant_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
         client_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
         scope: https://containerregistry.azure.net/.default
+```
+
+### Custom Authority Host (Azure Government example)
+
+```yaml
+- step:
+    type: Plugin
+    name: Azure OIDC (US Gov)
+    identifier: azure_oidc_usgov
+    spec:
+      connectorRef: harness-docker-connector
+      image: plugins/azure-oidc
+      settings:
+        tenant_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        client_id: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+        scope: https://management.azure.us/.default
+        azure_authority_host: https://login.microsoftonline.us
 ```
 
 ## Azure Prerequisites
@@ -167,7 +185,7 @@ az role assignment create \
 2. Plugin receives OIDC token via PLUGIN_OIDC_TOKEN_ID
    ↓
 3. Plugin exchanges OIDC token with Azure AD
-   POST https://login.microsoftonline.com/{tenant}/oauth2/v2.0/token
+   POST {azure_authority_host}/{tenant}/oauth2/v2.0/token (default: https://login.microsoftonline.com)
    ↓
 4. Azure AD validates the token against Federated Identity Credential
    ↓

--- a/plugin/plugin.go
+++ b/plugin/plugin.go
@@ -23,10 +23,11 @@ type Args struct {
 
 // Exec executes the plugin.
 func Exec(ctx context.Context, args Args) error {
+	// 1. verify Env variables
 	if err := VerifyEnv(args); err != nil {
 		return err
 	}
-
+	// 2. Exchange OIDC token for Azure AD access token
 	logrus.Infof("exchanging OIDC token for Azure AD access token")
 	tokenResp, err := ExchangeOIDCForAzureToken(
 		ctx,
@@ -39,7 +40,7 @@ func Exec(ctx context.Context, args Args) error {
 	if err != nil {
 		return fmt.Errorf("failed to exchange OIDC token: %w", err)
 	}
-
+	// 3. Write access token to output file
 	if err := WriteEnvToFile("AZURE_ACCESS_TOKEN", tokenResp.AccessToken); err != nil {
 		return err
 	}

--- a/plugin/plugin_test.go
+++ b/plugin/plugin_test.go
@@ -2,7 +2,15 @@
 
 package plugin
 
-import "testing"
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestVerifyEnv(t *testing.T) {
 	tests := []struct {
@@ -41,8 +49,8 @@ func TestVerifyEnv(t *testing.T) {
 			name: "all args provided",
 			args: Args{
 				OIDCToken: "oidc-token",
-				TenantID:  "tenant-id",
-				ClientID:  "client-id",
+				TenantID:  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+				ClientID:  "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
 			},
 			wantErr: false,
 		},
@@ -58,27 +66,132 @@ func TestVerifyEnv(t *testing.T) {
 	}
 }
 
-func TestWriteEnvToFile(t *testing.T) {
+func TestValidateGUID(t *testing.T) {
 	tests := []struct {
 		name    string
-		key     string
 		value   string
 		wantErr bool
 	}{
-		{
-			name:    "write to file",
-			key:     "AZURE_ACCESS_TOKEN",
-			value:   "test-token",
-			wantErr: false,
-		},
+		{name: "valid guid", value: "12345678-1234-1234-1234-1234567890ab", wantErr: false},
+		{name: "missing dashes", value: "123456781234123412341234567890ab", wantErr: true},
+		{name: "too short", value: "1234", wantErr: true},
+		{name: "wrong dash positions", value: "12345678-1234-1234-123412-34567890ab", wantErr: true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := WriteEnvToFile(tt.key, tt.value)
+			err := validateGUID(tt.value, "field")
 			if (err != nil) != tt.wantErr {
-				t.Errorf("WriteEnvToFile() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("validateGUID() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestWriteEnvToFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	outPath := filepath.Join(tmpDir, "out.env")
+	t.Setenv("HARNESS_OUTPUT_SECRET_FILE", outPath)
+
+	if err := WriteEnvToFile("AZURE_ACCESS_TOKEN", "test-token"); err != nil {
+		t.Fatalf("WriteEnvToFile returned error: %v", err)
+	}
+
+	// verify contents
+	data, err := os.ReadFile(outPath)
+	if err != nil {
+		t.Fatalf("failed reading output file: %v", err)
+	}
+	got := string(data)
+	wantLine := "AZURE_ACCESS_TOKEN=test-token\n"
+	if !strings.Contains(got, wantLine) {
+		t.Fatalf("output file missing line; got=%q want to contain %q", got, wantLine)
+	}
+}
+
+func TestExchangeOIDCForAzureToken_Success(t *testing.T) {
+	tenantID := "mytenant"
+	clientID := "12345678-1234-1234-1234-1234567890ab"
+	oidcToken := "oidc-token"
+
+	// mock azure token endpoint
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// verify method and path
+		if r.Method != http.MethodPost {
+			t.Fatalf("expected POST, got %s", r.Method)
+		}
+		expectedPath := "/" + tenantID + "/oauth2/v2.0/token"
+		if r.URL.Path != expectedPath {
+			t.Fatalf("unexpected path: got %s want %s", r.URL.Path, expectedPath)
+		}
+
+		// verify form fields
+		if err := r.ParseForm(); err != nil {
+			t.Fatalf("ParseForm error: %v", err)
+		}
+		if got := r.PostFormValue("client_id"); got != clientID {
+			t.Fatalf("client_id mismatch: got %s", got)
+		}
+		if got := r.PostFormValue("client_assertion_type"); got != "urn:ietf:params:oauth:client-assertion-type:jwt-bearer" {
+			t.Fatalf("client_assertion_type mismatch: %s", got)
+		}
+		if got := r.PostFormValue("client_assertion"); got != oidcToken {
+			t.Fatalf("client_assertion mismatch: %s", got)
+		}
+		if got := r.PostFormValue("grant_type"); got != "client_credentials" {
+			t.Fatalf("grant_type mismatch: %s", got)
+		}
+		// scope defaults when empty
+		if got := r.PostFormValue("scope"); got != defaultScope {
+			t.Fatalf("scope mismatch: got %q want %q", got, defaultScope)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"token_type":"Bearer","expires_in":3600,"access_token":"abc"}`))
+	}))
+	defer srv.Close()
+
+	ctx := context.Background()
+	token, err := ExchangeOIDCForAzureToken(ctx, oidcToken, tenantID, clientID, "", srv.URL)
+	if err != nil {
+		t.Fatalf("ExchangeOIDCForAzureToken returned error: %v", err)
+	}
+	if token == nil || token.AccessToken != "abc" || token.ExpiresIn != 3600 {
+		t.Fatalf("unexpected token response: %+v", token)
+	}
+}
+
+func TestExchangeOIDCForAzureToken_ErrorResponse(t *testing.T) {
+	tenantID := "mytenant"
+	clientID := "12345678-1234-1234-1234-1234567890ab"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte(`{"error":"invalid_client","error_description":"some long description","error_codes":[700016]}`))
+	}))
+	defer srv.Close()
+
+	_, err := ExchangeOIDCForAzureToken(context.Background(), "id-token", tenantID, clientID, "custom.scope/.default", srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "token exchange failed") {
+		t.Fatalf("expected token exchange failure, got %v", err)
+	}
+}
+
+func TestExchangeOIDCForAzureToken_BadJSON(t *testing.T) {
+	tenantID := "mytenant"
+	clientID := "12345678-1234-1234-1234-1234567890ab"
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"access_token":`)) // malformed JSON
+	}))
+	defer srv.Close()
+
+	_, err := ExchangeOIDCForAzureToken(context.Background(), "id-token", tenantID, clientID, defaultScope, srv.URL)
+	if err == nil || !strings.Contains(err.Error(), "failed to decode response") {
+		t.Fatalf("expected decode error, got %v", err)
 	}
 }


### PR DESCRIPTION
**Azure Authority Host & Scope Enhancements**
* Added support for the `azure_authority_host` parameter, allowing users to specify a custom Azure AD authority host for national clouds (e.g., Azure Government, China). The default is now `https://login.microsoftonline.com`. The default scope is changed to `https://management.azure.com/.default` instead of Azure Storage. Documentation and code reflect these updates. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R107) [[3]](diffhunk://#diff-639ad5fd2b33cf4bff2df96c2c88c4fda13f5def5da5c732bdc10e176d222fb3R36-R62)

**Documentation Updates**
* Updated the `README.md` to reflect new parameters, defaults, and usage examples for custom authority hosts and scopes. The docs now clarify supported values for `tenant_id` and provide sample YAML for Azure Government. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R31) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L59-R60) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91-R107) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L170-R188)

**Comprehensive Testing**
* Added new tests covering environment validation, GUID format, writing secrets to output files, and the Azure token exchange logic including error and edge cases. [[1]](diffhunk://#diff-b947de162d1c0f76edfd634a11a7b132df3d20671512152f1b50e982f94ae462L5-R13) [[2]](diffhunk://#diff-b947de162d1c0f76edfd634a11a7b132df3d20671512152f1b50e982f94ae462L44-R53) [[3]](diffhunk://#diff-b947de162d1c0f76edfd634a11a7b132df3d20671512152f1b50e982f94ae462L61-R197)
<img width="1725" height="999" alt="Screenshot 2025-10-27 at 11 28 12 AM" src="https://github.com/user-attachments/assets/1ddece20-a27e-449f-b835-b307c2594d2e" />
<img width="1728" height="998" alt="Screenshot 2025-10-27 at 11 28 32 AM" src="https://github.com/user-attachments/assets/2ec65297-7cea-42e9-b77f-f2f0cdb3c6bf" />
