### PR TITLE
fix: [CI-23224] remediate vulnerabilities in harnesssecure/azure-oidc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,12 @@
 module github.com/harness-community/drone-azure-oidc
 
-go 1.23.0
+go 1.24.0
+
+toolchain go1.25.11
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/sirupsen/logrus v1.9.3
 )
 
-require golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 // indirect
+require golang.org/x/sys v0.36.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,9 @@ github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVs
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
-golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8 h1:0A+M6Uqn+Eje4kHMK80dtF3JCXC4ykBgQG4Fe06QRhQ=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
+golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
## Vulnerability Remediation: harnesssecure/azure-oidc

**Team:** ci (Harness CI Platform)
**Tickets:** [CI-23224](https://harness.atlassian.net/browse/CI-23224)
**Test image:** `vinayakharness/azure-oidc-test:azure-oidc-1.0.1--debug`

**OnDemand scanner runs (Harness https://harness0.harness.io):**
- Baseline: [8U5-PtRWSpSX1h6mNzvA8g](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/8U5-PtRWSpSX1h6mNzvA8g/pipeline)
- After:    [-PY3onTlRYyQQqiipKKcJA](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/-PY3onTlRYyQQqiipKKcJA/pipeline)

---

### Summary

All 13 vulnerability findings (1 Critical / 5 High / 2 Medium / 1 Low / 4 Info on Prisma Cloud + 1 Medium on Snyk + Trivy's 49 stdlib findings) are resolved by recompiling the binary with Go 1.25.11 and bumping `golang.org/x/sys` to v0.36.0. The base image is `scratch`, so the only attack surface is the Go binary itself — every CVE was traced to either the Go stdlib bundled into the binary (Go 1.23.0) or the very old (2022-07) `golang.org/x/sys` indirect dependency. Both Trivy and Harness OnDemand (Snyk + Prisma Cloud) report **0 CVEs** on the rebuilt test image. **Recommendation: SHIP.**

---

### CVE Delta — Trivy (local scan)

| Severity | Before | After | Change |
|----------|--------|-------|--------|
| Critical | 1      | 0     | -1     |
| High     | 16     | 0     | -16    |
| Medium   | 29     | 0     | -29    |
| Low      | 3      | 0     | -3     |
| Total    | 49     | 0     | -49    |

### CVE Delta — Harness OnDemand (Snyk + Prisma Cloud)

| Severity | Before | After | Change |
|----------|--------|-------|--------|
| Critical | 1      | 0     | -1     |
| High     | 5      | 0     | -5     |
| Medium   | 2      | 0     | -2     |
| Low      | 1      | 0     | -1     |
| Info     | 4      | 0     | -4     |
| Total    | 13     | 0     | -13    |

---

### Per-Ticket CVE Status

#### CI-23224 — [P2: Security Vulnerability Fixes - harnesssecure/azure-oidc](https://harness.atlassian.net/browse/CI-23224)

The ticket reports an aggregate count (1 Critical / 10 High / 6 Medium / 1 Low / 18 unique) and points readers to the live posture board for the per-CVE list. Both scanners enumerated the actual CVEs against the live image; all of them are resolved by this PR.

| CVE | Package | Before | After | Required | Status | Reason |
|-----|---------|--------|-------|----------|--------|--------|
| CVE-2025-68121 | stdlib (crypto/tls) | go1.23.0 | go1.25.11 | ≥1.25.7 | OK | Toolchain bumped |
| CVE-2025-61726 | stdlib (net/url)    | go1.23.0 | go1.25.11 | ≥1.25.6 | OK | Toolchain bumped |
| CVE-2025-61729 | stdlib (crypto/x509)| go1.23.0 | go1.25.11 | ≥1.25.5 | OK | Toolchain bumped |
| CVE-2026-25679 | stdlib (net/url)    | go1.23.0 | go1.25.11 | ≥1.25.8 | OK | Toolchain bumped |
| CVE-2026-27145 | stdlib (crypto/x509)| go1.23.0 | go1.25.11 | ≥1.25.11 | OK | Toolchain bumped |
| CVE-2026-32280 | stdlib (crypto/x509)| go1.23.0 | go1.25.11 | ≥1.25.9 | OK | Toolchain bumped |
| CVE-2026-32281 | stdlib (crypto/x509)| go1.23.0 | go1.25.11 | ≥1.25.9 | OK | Toolchain bumped |
| CVE-2026-32283 | stdlib (crypto/tls) | go1.23.0 | go1.25.11 | ≥1.25.9 | OK | Toolchain bumped |
| CVE-2026-33811 | stdlib (net)        | go1.23.0 | go1.25.11 | ≥1.25.10 | OK | Toolchain bumped |
| CVE-2026-33814 | stdlib (net/http2)  | go1.23.0 | go1.25.11 | ≥1.25.10 | OK | Toolchain bumped |
| CVE-2026-39820 | stdlib (net/mail)   | go1.23.0 | go1.25.11 | ≥1.25.10 | OK | Toolchain bumped |
| CVE-2026-39823 | stdlib (net/url)    | go1.23.0 | go1.25.11 | ≥1.25.10 | OK | Toolchain bumped |
| CVE-2026-39825 | stdlib (httputil)   | go1.23.0 | go1.25.11 | ≥1.25.10 | OK | Toolchain bumped |
| CVE-2026-39836 | stdlib (multiple)   | go1.23.0 | go1.25.11 | ≥1.25.10 | OK | Toolchain bumped |
| CVE-2026-42499 | stdlib (net/mail)   | go1.23.0 | go1.25.11 | ≥1.25.10 | OK | Toolchain bumped |
| CVE-2026-42504 | stdlib (mime)       | go1.23.0 | go1.25.11 | ≥1.25.11 | OK | Toolchain bumped |
| CVE-2024-34155, CVE-2024-34156, CVE-2024-34158, CVE-2024-45336, CVE-2024-45341, CVE-2025-0913, CVE-2025-22866, CVE-2025-22870, CVE-2025-22871, CVE-2025-22873, CVE-2025-4673, CVE-2025-47906, CVE-2025-47907, CVE-2025-47912, CVE-2025-58183, CVE-2025-58185, CVE-2025-58187, CVE-2025-58188, CVE-2025-58189, CVE-2025-61723, CVE-2025-61724, CVE-2025-61725, CVE-2025-61727, CVE-2025-61728, CVE-2025-61730, CVE-2026-27139, CVE-2026-27142, CVE-2026-32282, CVE-2026-32288, CVE-2026-32289, CVE-2026-39826, CVE-2026-42507, CVE-2025-58186 | stdlib (assorted) | go1.23.0 | go1.25.11 | various ≤1.25.11 | OK | Toolchain bumped |
| CVE-2022-29526 | golang.org/x/sys | v0.0.0-20220715151400-c0bba94af5f8 | v0.36.0 | ≥v0.0.0-20220908121316 | OK | Indirect dep bumped |

(Status legend: OK = Resolved, PARTIAL = improved but below fix threshold, BLOCKED = no upstream fix available.)

---

### Changes Made

| File | Change |
|------|--------|
| `go.mod` | Added `toolchain go1.25.11` directive; bumped `go` directive to `1.24.0` (required by `golang.org/x/sys v0.36.0`); bumped `golang.org/x/sys` from `v0.0.0-20220715151400-c0bba94af5f8` to `v0.36.0`. |
| `go.sum`  | Updated hashes for `golang.org/x/sys` v0.36.0. |

**Version selection rationale:**
- **Go toolchain → 1.25.11**: This is the minimum Go release that fixes every stdlib CVE flagged by Trivy on the baseline image. The most stringent CVEs (CVE-2026-27145, CVE-2026-42504) require 1.25.11; older fixes are also picked up. Staying on the 1.25 series instead of jumping to 1.26 keeps the upgrade scoped to the active LTS-equivalent minor release.
- **golang.org/x/sys → v0.36.0**: The original pseudo-version (2022-07) predates the fix for CVE-2022-29526. v0.36.0 is the current release and is what `go mod tidy` chooses with Go 1.25.11; older `v0.x.y` tags would also fix the CVE but `tidy` already selected a maintained release.
- **Dockerfile unchanged**: The `FROM scratch` base contributes no OS packages to the image, so no base-image bump is needed. Re-compiling the binary with Go 1.25.11 alone embeds new stdlib versions into the binary, which is what Snyk/Prisma/Trivy actually scan.

---

### Build / Verification

- Built `release/linux/amd64/drone-azure-oidc` and `release/linux/arm64/drone-azure-oidc` inside `golang:1.25.11-alpine` (`CGO_ENABLED=0`, `-trimpath`, `-ldflags="-s -w"`).
- Confirmed embedded toolchain with `go version <binary>` → `go1.25.11`.
- Trivy 0.71.2 — baseline 49 CVEs, after rebuild **0 CVEs**.
- Harness OnDemand (Snyk + Prisma) — baseline 13 findings (1 Critical / 5 High / 2 Medium / 1 Low / 4 Info), after rebuild **0 findings**.

> ⚠️ This image's existing CI builds the binary outside the Dockerfile (`scripts/build.sh`) and bakes it via `ADD release/linux/amd64/drone-azure-oidc`. The CI build pipeline (Drone/Harness build pipeline) must use a Go ≥ 1.25.11 toolchain when it runs `scripts/build.sh`; the `toolchain` directive in `go.mod` will trigger the correct download via `GOTOOLCHAIN`. If the build runner pins a fixed Go version with `GOTOOLCHAIN=local`, that pin needs to be ≥ 1.25.11.

---


[CI-23224]: https://harness.atlassian.net/browse/CI-23224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ