### PR TITLE
fix: [CI-23793] bump Go toolchain to 1.25.12 for harnesssecure/azure-oidc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/harness-community/drone-azure-oidc
 
 go 1.24.0
 
-toolchain go1.25.11
+toolchain go1.25.12
 
 require (
 	github.com/kelseyhightower/envconfig v1.4.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harness-community/drone-azure-oidc
 
-go 1.24.0
+go 1.25.12
 
 toolchain go1.25.12
 

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/harness-community/drone-azure-oidc
 
 go 1.25.12
 
-toolchain go1.25.12
-
 require (
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/sirupsen/logrus v1.9.3

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,8 +10,8 @@ set -e
 set -x
 
 # linux
-GOOS=linux GOARCH=amd64 go build -o release/linux/amd64/drone-azure-oidc
-GOOS=linux GOARCH=arm64 go build -o release/linux/arm64/drone-azure-oidc
+GOOS=linux GOARCH=amd64 go build -buildvcs=false -o release/linux/amd64/drone-azure-oidc
+GOOS=linux GOARCH=arm64 go build -buildvcs=false -o release/linux/arm64/drone-azure-oidc
 
 # windows
 GOOS=windows go build -buildvcs=false -o release/windows/amd64/drone-azure-oidc.exe

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,8 +10,8 @@ set -e
 set -x
 
 # linux
-GOOS=linux GOARCH=amd64 go build -buildvcs=false -o release/linux/amd64/drone-azure-oidc
-GOOS=linux GOARCH=arm64 go build -buildvcs=false -o release/linux/arm64/drone-azure-oidc
+GOOS=linux GOARCH=amd64 go build -o release/linux/amd64/drone-azure-oidc
+GOOS=linux GOARCH=arm64 go build -o release/linux/arm64/drone-azure-oidc
 
 # windows
 GOOS=windows go build -buildvcs=false -o release/windows/amd64/drone-azure-oidc.exe

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,8 +10,8 @@ set -e
 set -x
 
 # linux
-GOOS=linux GOARCH=amd64 go build -o release/linux/amd64/drone-azure-oidc
-GOOS=linux GOARCH=arm64 go build -o release/linux/arm64/drone-azure-oidc
+GOOS=linux GOARCH=amd64 go build -buildvcs=false -o release/linux/amd64/drone-azure-oidc
+GOOS=linux GOARCH=arm64 go build -buildvcs=false -o release/linux/arm64/drone-azure-oidc
 
 # windows
-GOOS=windows go build -o release/windows/amd64/drone-azure-oidc.exe
+GOOS=windows go build -buildvcs=false -o release/windows/amd64/drone-azure-oidc.exe


### PR DESCRIPTION
Remediates security vulnerabilities in `harnesssecure/azure-oidc` ([Jira CI-23793](https://harness.atlassian.net/browse/CI-23793)).

Rebuilds the Azure OIDC plugin with **Go 1.25.12** and synced dependencies. Production `latest` still carried an old Go stdlib binary despite CI-23224 (PR #4, Go 1.25.11) — this PR bumps the toolchain to the GCS-aligned patch level, fixes CI build failures, and validates via debug tag before merge.

| | |
|---|---|
| **Baseline** | `harnesssecure/azure-oidc:latest` (stale production image) |
| **Source repo** | [harness-community/drone-azure-oidc](https://github.com/harness-community/drone-azure-oidc) |
| **Test image (final)** | `harnesssecure/azure-oidc:1.0.0-debug-ci23793-r2` |
| **Git tag** | `v1.0.0-debug-ci23793-r2` → commit [`eefa3ef`](https://github.com/harness-community/drone-azure-oidc/commit/eefa3ef) |

---

## Changes

| Area | What changed |
|------|--------------|
| `go.mod` / `go.sum` | Go `1.25.11` → **`1.25.12`** + `go mod tidy` |
| `scripts/build.sh` | Add `-buildvcs=false` to all `go build` commands |
| Harness build pipeline (`droneazureoidc`) | Builder image `golang:1.24.0` → **`golang:1.25.12`** (8 occurrences, UI update) |

### Code / CI fixes (why pipeline failed after Go bump)

| Issue | Fix |
|-------|-----|
| `go.mod requires go >= 1.25.12 (running go 1.24.0)` | Updated pipeline builder to `golang:1.25.12` |
| `go.mod` / `go.sum` out of sync | Ran `go mod tidy` locally and committed |
| Windows: `error obtaining VCS status: exit status 128` | Added `-buildvcs=false` in `scripts/build.sh` (all targets — `win-amd64` runs full `build.sh` including Linux cross-compile lines) |

> Review note: scoped `-buildvcs=false` to Windows-only was tried and reverted — `win-amd64` stage executes Linux build lines first on the Windows runner, so all `go build` lines need the flag.

---

## Build & publish

| Item | Value |
|------|-------|
| **Git tag** | `v1.0.0-debug-ci23793-r2` → commit `eefa3ef` |
| **Pipeline** | [`droneazureoidc` tag run — Success](https://app.harness.io/ng/account/gCoPSwHxS7ipOgx2iA9tOQ/module/ci/orgs/default/projects/Drone_Plugins/pipelines/droneazureoidc/executions/5sTyci0iRvOPxnvJkC6aYg/pipeline) |
| **Image published** | `harnesssecure/azure-oidc:1.0.0-debug-ci23793-r2` |



---

## Vulnerability scan (OnDemand)

**Scanner:** Harness OnDemand (Snyk + Prisma)

### Severity comparison

| Severity | Before (`harnesssecure/azure-oidc:latest`) | After (`harnesssecure/azure-oidc:1.0.0-debug-ci23793-r2`) | Delta |
|----------|---------------------------------------------|-----------------------------------------------------------|-------|
| **Critical** | 1 | **0** | ✅ −1 |
| **High** | 5 | **0** | ✅ −5 |
| **Low** | see scan | see scan | — |

### Scan details

| Scan | Image tag | Result | Link |
|------|-----------|--------|------|
| **Before** | `latest` | 1 Critical, 5 High | [OnDemand execution](https://harness0.harness.io/ng/account/l7B_kbSEQD2wjrM7PShm5w/all/orgs/Security_and_Compliance/projects/ProdSec/pipelines/Ondemand_Vulnerability_Scanner/executions/yHXZgwJrS3m3l8KvZ_NPjQ/security) |
| **After** | `1.0.0-debug-ci23793-r2` | **0 Critical, 0 High** | OnDemand on debug tag (use tag **without** `v` prefix) |

### RF base image (ruled out)

| Image | Critical | High | Low | Conclusion |
|-------|----------|------|-----|------------|
| `rf-curated/ubuntu:24.04-curated` | 0 | 0 | 1 | Base clean — Crit/High on `azure-oidc:latest` were from **Go stdlib in the binary** |

**Outcome:** All Critical/High resolved on the `-r2` debug image.

---

## Functional validation

**Pipeline:** `CI23793AzureOidcFunctionalTests` (Automation-derived) — **5/5 stages passed** on `harnesssecure/azure-oidc:1.0.0-debug-ci23793-r2`

| Infra | Stage | Automation source | Result |
|-------|-------|-------------------|--------|
| Harness Cloud | vm-linux-amd64-oidc | `oidc-token-with-azure-hosted-linux` / `vm/linux/plugin/oidc-token-with-azure.yml` | ✅ Pass |
| Harness Cloud | vm-linux-arm64-oidc | `vm/linux/plugin/oidc-token-with-azure-arm64.yml` | ✅ Pass |
| K8 Direct (`hcli`) | k8-linux-oidc | `oidc-token-with-azure-k8-linux` / `k8/linux/steps/plugin/oidc-token-with-azure.yml` | ✅ Pass |
| Harness Cloud | vm-linux-image-pull | `vm/linux/run/run-azure-oidc-image-pull.yml` | ✅ Pass |
| K8 Direct (`hcli`) | k8-linux-image-pull | `k8/linux/steps/run/run-azure-oidc-image-pull.yml` | ✅ Pass |

**Execution:** [Functional test run — `1.0.0-debug-ci23793-r2` (5/5 pass)](https://qa.harness.io/ng/account/h61p38AZSV6MzEkpWWBtew/all/orgs/default/projects/default_project/pipelines/CI23793AzureOidcFunctionalTests/executions/ulpTENEnTuyWUng-WXuAXA/pipeline)

**Flow per OIDC stage:** Azure OIDC plugin → `AZURE_ACCESS_TOKEN` → `az rest` (Azure Management API / subscriptions)

> Covers Abhay-requested cases: **Cloud hosted** (`oidc-token-with-azure-hosted-linux`) + **K8** (`oidc-token-with-azure-k8-linux`). `docker/osx/plugin/oidc-token-with-azure.yml` omitted — Docker runtime infra not configured in QA.

---

## CI status

| Check | Status |
|-------|--------|
| `droneazureoidc` — PR checks (incl. revert commit) | ✅ Green |
| `droneazureoidc` — tag `v1.0.0-debug-ci23793-r2` publish | ✅ Success |
| Pipeline builder `golang:1.25.12` | ✅ (required for `go.mod`) |

---

## Post-merge

- [ ] Merge PR
- [ ] Push release git tag → publish `harnesssecure/azure-oidc:latest`
- [ ] Final OnDemand scan on `latest` (target **0 Critical / 0 High**)
- [ ] Close [CI-23793](https://harness.atlassian.net/browse/CI-23793)

---

## Related

| | |
|---|---|
| **Jira** | [CI-23793](https://harness.atlassian.net/browse/CI-23793) |
| **Prior work** | [CI-23224](https://harness.atlassian.net/browse/CI-23224) / [PR #4](https://github.com/harness-community/drone-azure-oidc/pull/4) (Go 1.25.11 — merged but `latest` never republished) |
| **Branch** | `fix/CI-23793-vuln-remediation` |
| **Pattern** | GCS remediation ([CI-23226](https://harness.atlassian.net/browse/CI-23226)) |


[CI-23793]: https://harness.atlassian.net/browse/CI-23793?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ